### PR TITLE
Support "bahaha" in counts of "bwahaha"

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -64,7 +64,7 @@
           ('TNAKs', '\\b[Tt][Nn][Aa][Kk]\\b'),
           ('LOLs', '\\b([Ll]+[Oo]+)([Ll]+([Oo]+)?)+\\b'),
           ('HAHAs', '\\b([Hh]+[Aa]+)+\\b'),
-          ('BWAHAHAs', '\\b[Bb][Ww][Aa]([Hh]+[Aa]+)+\\b')
+          ('BWAHAHAs', '\\b[Bb][Ww]*[Aa]([Hh]+[Aa]+)+\\b')
         ],
         coarse=True,
         cumulative=True,


### PR DESCRIPTION
Occasionally we miss a "W" in "Bwhahaha". The graph on the index page should reflect that.
