### PR TITLE
I fixed a circular import in web.logs.

### DIFF
--- a/web/logs/inmemory_engine.py
+++ b/web/logs/inmemory_engine.py
@@ -10,7 +10,7 @@ import time
 
 from web import app, APP_STATIC # Keep web import for app and APP_STATIC
 from .abstract_engine import AbstractLogQueryEngine # Import from local abstract_engine
-from ..logs import VALID_NICKS # Import VALID_NICKS from the logs package __init__
+from .constants import VALID_NICKS # Import VALID_NICKS from the logs package __init__
 
 class InMemoryLogQueryEngine(AbstractLogQueryEngine):
     def __init__(self, log_file_path=None, log_data=None):


### PR DESCRIPTION
I resolved a circular import error. This happened because `web.logs.inmemory_engine` was importing `VALID_NICKS` from `web.logs.__init__`, while `web.logs.__init__` was also importing from `web.logs.inmemory_engine`.

To fix this, I updated `web.logs.inmemory_engine` to import `VALID_NICKS` directly from `web.logs.constants`.